### PR TITLE
Fix whitespace issue in partial

### DIFF
--- a/_includes/component.html
+++ b/_includes/component.html
@@ -9,9 +9,9 @@
       {{ entry.content }}
     </div>
     <div class="sg-component__source">
-      {% highlight html %}
-        {{ entry.content }}
-      {% endhighlight %}
+{% highlight html %}
+{{ entry.content }}
+{% endhighlight %}
     </div>
   </div>
 


### PR DESCRIPTION
Loving the project..exactly what I was needing. I noticed there was a whitespace issue that had to do with the `tab` indent in the `component.html` partial. It was creating a big gap on the first line of the Pygment code fragment.

<img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/15309/white-space-issue.png" alt="Code fragment showing whitespace issue">

---

By removing the whitespace in the partial it seemed to fix. Must be a Python spaces/tabs thing.

---

<img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/15309/white-issue-fixed.png" alt="Code fragment showing whitespace issue">
